### PR TITLE
fix: Revert RITM2000 changes pending deformation model investigation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linz-coordsys (1.13.1-1) focal; urgency=medium
+
+  * fix: Reverting Raoul Island TM pending deformation model investigation
+
+ -- Chris Crook <ccrook@linz.govt.nz>  Mon, 25 Jun 2022 10:00:00 +1200
+
 linz-coordsys (1.13.0-1) focal; urgency=medium
 
   * fix: Raoul Island TM changed to NZGD2000

--- a/files/coordsys.def
+++ b/files/coordsys.def
@@ -651,7 +651,7 @@ CATM2000 "Campbell Island Transverse Mercator 2000" REF_FRAME ITRF96 &
 CITM2000 "Chatham Islands Transverse Mercator 2000" REF_FRAME NZGD2000 &
           PROJECTION TM -176.5 0.0 1.0 3500000.0 10000000.0 1.0
 
-RITM2000 "Raoul Island Transverse Mercator 2000" REF_FRAME NZGD2000 &
+RITM2000 "Raoul Island Transverse Mercator 2000" REF_FRAME ITRF96 &
           PROJECTION TM -178.0 0.0 1.0 3500000.0 10000000.0 1.0
 
 ! Continental Shelf Projection


### PR DESCRIPTION
Reverting RITM2000 to be based on ITRF96 until suitability of deformation model for use in Kermadec region assessed